### PR TITLE
Scenario 1030 updated

### DIFF
--- a/Create_ teacher_private_spaces.jmx
+++ b/Create_ teacher_private_spaces.jmx
@@ -23,7 +23,7 @@
   &quot;ext_user_id&quot;: &quot;${extuserid}&quot;,&#xd;
   &quot;ext_role&quot;: &quot;teacher&quot;,&#xd;
   &quot;ext_first_name&quot;: &quot;${extuserid}&quot;,&#xd;
-  &quot;ext_last_name&quot;: &quot;test&quot;&#xd;
+  &quot;ext_last_name&quot;: &quot;Perf Test&quot;&#xd;
 }</stringProp>
                 <stringProp name="Argument.metadata">=</stringProp>
               </elementProp>

--- a/c1_perf_test_all_scenario.jmx
+++ b/c1_perf_test_all_scenario.jmx
@@ -5036,11 +5036,6 @@ vars.put(&quot;extuserid&quot;, extuserid);
               <stringProp name="IncludeController.includepath">Create_ teacher_private_spaces.jmx</stringProp>
             </IncludeController>
             <hashTree/>
-            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Revoke a workflow request" enabled="false">
-              <stringProp name="IncludeController.includepath">Revoke_a_workflow_request.jmx</stringProp>
-              <stringProp name="TestPlan.comments">This will be updated once &quot;Create a workflow request&quot; is supported. Called only if above step is failed to create private space</stringProp>
-            </IncludeController>
-            <hashTree/>
             <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Wait time for space enrollment" enabled="true">
               <intProp name="ActionProcessor.action">1</intProp>
               <intProp name="ActionProcessor.target">0</intProp>

--- a/c1_perf_test_all_scenario.jmx
+++ b/c1_perf_test_all_scenario.jmx
@@ -5008,12 +5008,10 @@ vars.put(&quot;classname&quot;, classname);</stringProp>
             <stringProp name="filename"></stringProp>
             <stringProp name="parameters"></stringProp>
             <boolProp name="resetInterpreter">false</boolProp>
-            <stringProp name="script">prefix0 = vars.get(&quot;testrun&quot;);
-prefix1 = &quot;teacher_1030&quot;;
-prefix2 = vars.get(&quot;date&quot;);
-prefix3 = ctx.getThread().getThreadNum() + 1;
+            <stringProp name="script">prefix1 = vars.get(&quot;date&quot;);
+prefix2 = ctx.getThread().getThreadNum() + 1;
 
-extuserid = prefix0 + &quot;_&quot; + prefix1 + &quot;_&quot; + prefix2 + &quot;_&quot; + prefix3;
+extuserid = &quot;tch_&quot; + prefix1 + &quot;_&quot; + prefix2;
 
 vars.put(&quot;extuserid&quot;, extuserid);
 </stringProp>
@@ -5021,12 +5019,26 @@ vars.put(&quot;extuserid&quot;, extuserid);
           <hashTree/>
           <OnceOnlyController guiclass="OnceOnlyControllerGui" testclass="OnceOnlyController" testname="Once Only Controller" enabled="true"/>
           <hashTree>
-            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get All the User Spaces" enabled="false">
-              <stringProp name="IncludeController.includepath">Get_all_the_User_Spaces.jmx</stringProp>
+            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get All the User Spaces" enabled="true">
+              <stringProp name="IncludeController.includepath">Get_all_the_User_Spaces_no_spaces.jmx</stringProp>
+            </IncludeController>
+            <hashTree/>
+            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get all the workflow requests, made by a particular user" enabled="true">
+              <stringProp name="IncludeController.includepath">Get_all_the_workflow_requests_made_by_a_particular_user.jmx</stringProp>
+            </IncludeController>
+            <hashTree/>
+            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Create a new workflow request" enabled="false">
+              <stringProp name="IncludeController.includepath"></stringProp>
+              <stringProp name="TestPlan.comments">Not supported yet</stringProp>
             </IncludeController>
             <hashTree/>
             <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Create (registration only) teacher private spaces. Any existing teacher cannot get shared space." enabled="true">
               <stringProp name="IncludeController.includepath">Create_ teacher_private_spaces.jmx</stringProp>
+            </IncludeController>
+            <hashTree/>
+            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Revoke a workflow request" enabled="false">
+              <stringProp name="IncludeController.includepath">Revoke_a_workflow_request.jmx</stringProp>
+              <stringProp name="TestPlan.comments">This will be updated once &quot;Create a workflow request&quot; is supported. Called only if above step is failed to create private space</stringProp>
             </IncludeController>
             <hashTree/>
             <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Wait time for space enrollment" enabled="true">
@@ -5045,22 +5057,6 @@ vars.put(&quot;extuserid&quot;, extuserid);
               <stringProp name="IncludeController.includepath">Get_all_the_User_Spaces.jmx</stringProp>
             </IncludeController>
             <hashTree/>
-            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get an access token for an external user" enabled="true">
-              <stringProp name="IncludeController.includepath">Get_an_access_token_for_an_external_user.jmx</stringProp>
-            </IncludeController>
-            <hashTree/>
-            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get classes of an user" enabled="true">
-              <stringProp name="IncludeController.includepath">Get_classes_of_an_user.jmx</stringProp>
-            </IncludeController>
-            <hashTree/>
-            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get all bundles" enabled="true">
-              <stringProp name="IncludeController.includepath">Get_all_bundles.jmx</stringProp>
-            </IncludeController>
-            <hashTree/>
-            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get global entitlements of a user" enabled="true">
-              <stringProp name="IncludeController.includepath">Get_global_entitlements_of_a_user.jmx</stringProp>
-            </IncludeController>
-            <hashTree/>
             <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Wait time on dashboard" enabled="true">
               <intProp name="ActionProcessor.action">1</intProp>
               <intProp name="ActionProcessor.target">0</intProp>
@@ -5073,6 +5069,10 @@ vars.put(&quot;extuserid&quot;, extuserid);
               </UniformRandomTimer>
               <hashTree/>
             </hashTree>
+            <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get all the workflow requests, made by a particular user" enabled="true">
+              <stringProp name="IncludeController.includepath">Get_all_the_workflow_requests_made_by_a_particular_user.jmx</stringProp>
+            </IncludeController>
+            <hashTree/>
             <ResultCollector guiclass="ViewResultsFullVisualizer" testclass="ResultCollector" testname="View Results Tree" enabled="false">
               <boolProp name="ResultCollector.error_logging">false</boolProp>
               <objProp>


### PR DESCRIPTION
1030: Teacher registers using a Institution code and accesses first time / default dashboard, get access to products in that institution

1. c1_perf_test_all_scenario.jmx

- Updated Beanshell Preprocessor to update ext user id format
- Updated fragment from "Get_all_the_User_Spaces.jmx" to "Get_all_the_User_Spaces_no_spaces.jmx"
- Added fragment "Get_all_the_workflow_requests_made_by_a_particular_user.jmx"
- Added dummy disabled fragment for "Create a new workflow request" as it is not supported yet
- Added disabled fragment "Revoke_a_workflow_request.jmx". Will be fixed when "Create a new workflow request" is supported
- Added fragment "Get_all_the_workflow_requests_made_by_a_particular_user.jmx"
- Removed fragment "Get_an_access_token_for_an_external_user.jmx"
- Removed fragment "Get_classes_of_an_user.jmx"
- Removed fragment "Get_all_bundles.jmx"
- Removed fragment "Get_global_entitlements_of_a_user.jmx"

2. Create_ teacher_private_spaces.jmx

- Updated Last Name as per the finalized naming convention
