### PR TITLE
UPDATES FOR SCENARIO 1041

### DIFF
--- a/Get_invitation_by_email.jmx
+++ b/Get_invitation_by_email.jmx
@@ -50,7 +50,7 @@
           </HeaderManager>
           <hashTree/>
           <JSONPathAssertion guiclass="JSONPathAssertionGui" testclass="JSONPathAssertion" testname="JSON Assertion" enabled="true">
-            <stringProp name="JSON_PATH">$.entities[0].invitation_id</stringProp>
+            <stringProp name="JSON_PATH">$.entities</stringProp>
             <stringProp name="EXPECTED_VALUE"></stringProp>
             <boolProp name="JSONVALIDATION">false</boolProp>
             <boolProp name="EXPECT_NULL">false</boolProp>

--- a/c1_perf_test_all_scenario.jmx
+++ b/c1_perf_test_all_scenario.jmx
@@ -223,7 +223,7 @@
             </elementProp>
             <elementProp name="invitationorgid" elementType="Argument">
               <stringProp name="Argument.name">invitationorgid</stringProp>
-              <stringProp name="Argument.value">${__P(invitationorgid,integ-test1-alpha)}</stringProp>
+              <stringProp name="Argument.value">${__P(invitationorgid,perf-test1-alpha)}</stringProp>
               <stringProp name="Argument.metadata">=</stringProp>
             </elementProp>
             <elementProp name="itemcode2" elementType="Argument">
@@ -2539,7 +2539,7 @@ vars.put(&quot;firstname&quot;, firstname);</stringProp>
             <boolProp name="recycle">true</boolProp>
             <stringProp name="shareMode">shareMode.group</stringProp>
             <boolProp name="stopThread">false</boolProp>
-            <stringProp name="variableNames">extuserid,class_code,classid,invitation_id</stringProp>
+            <stringProp name="variableNames">extuserid,classcode,classid,invitation_id</stringProp>
           </CSVDataSet>
           <hashTree/>
           <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get Single invitation of a class" enabled="true">
@@ -2562,8 +2562,24 @@ vars.put(&quot;firstname&quot;, firstname);</stringProp>
             <stringProp name="IncludeController.includepath">Get_enrollments_of_users_in_class.jmx</stringProp>
           </IncludeController>
           <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="API to grant authkey on refid" enabled="true">
+            <stringProp name="IncludeController.includepath">API_to_grant_authkey_on_refid.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get Product details using ISBN" enabled="false">
+            <stringProp name="IncludeController.includepath">Get_product_details_by_isbn_evolvel1.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get a particular Bundle" enabled="false">
+            <stringProp name="IncludeController.includepath">Get_a_Particular_Bundle.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Create (registration only) student spaces (private and optionally institutional) with product_code and class_code" enabled="false">
+            <stringProp name="IncludeController.includepath">Join_Spaces_with_product_code_and_class_code_private.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
           <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Join Spaces with class_code" enabled="true">
-            <stringProp name="IncludeController.includepath">Join_Spaces_with_class_code_invitation.jmx</stringProp>
+            <stringProp name="IncludeController.includepath">Join_Spaces_with_class_code.jmx</stringProp>
           </IncludeController>
           <hashTree/>
           <TestAction guiclass="TestActionGui" testclass="TestAction" testname="Wait time for joining class" enabled="true">
@@ -2584,6 +2600,34 @@ vars.put(&quot;firstname&quot;, firstname);</stringProp>
           <hashTree/>
           <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Complete invitations of user" enabled="true">
             <stringProp name="IncludeController.includepath">complete_invitation_of_user.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get Invitations By Email" enabled="true">
+            <stringProp name="IncludeController.includepath">Get_invitation_by_email.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get all the User Spaces" enabled="true">
+            <stringProp name="IncludeController.includepath">Get_all_the_User_Spaces.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get Global Entitlements of a user" enabled="true">
+            <stringProp name="IncludeController.includepath">Get_global_entitlements_of_a_user.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get an access token for an external user" enabled="true">
+            <stringProp name="IncludeController.includepath">Get_an_access_token_for_an_external_user_institution.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get classes of an user" enabled="true">
+            <stringProp name="IncludeController.includepath">Get_classes_of_an_user.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Product Items and their Progress Analytics (default)" enabled="true">
+            <stringProp name="IncludeController.includepath">Product_items_and_their_progress_analytic_default.jmx</stringProp>
+          </IncludeController>
+          <hashTree/>
+          <IncludeController guiclass="IncludeControllerGui" testclass="IncludeController" testname="Get assigned paths of a user in a class" enabled="true">
+            <stringProp name="IncludeController.includepath">Get_list_of_assignments_assigned_to_a_learner_in_class.jmx</stringProp>
           </IncludeController>
           <hashTree/>
           <DebugSampler guiclass="TestBeanGUI" testclass="DebugSampler" testname="Debug Sampler" enabled="false">


### PR DESCRIPTION
1041:
1. Added call for "API to grant authkey on refid".
2. Added call for "Get Product details using ISBN". and disabled it
3. Added call for "Get a particular Bundle"and disabled it.
4. Added call for "Create (registration only) student spaces (private and optionally institutional) with product_code and class_code." and disabled it.
5. Added call for "Get Invitations By Email".
6. Added call for "Get_all_the_User_Spaces.jmx", "Get Global Entitlements of a user", "Get_classes_of_an_user", "Product Items and their Progress Analytics (default)" and "Get assigned paths of a user in a class".
7. Changed call for "Join spaces with class code_invitation" to "Join spaces with class code".
9. Chnaged "class_code" in "CSV Data Set Config" to "classcode".
10. In Fragment "Get Invitation by Email.jmx" Changed assertion from "$.entities[0].invitation_id" to "$.entities".